### PR TITLE
Fixup setup.sh group modification and add selinux info.

### DIFF
--- a/README
+++ b/README
@@ -39,12 +39,14 @@ Copyright (c) 2006-2013 Trend Micro Inc.
     module ossec-wui 1.0;
 
     require {
+	type var_log_t;
         type httpd_t;
         type var_t;
         class file { read getattr open };
     }
 
     #============= httpd_t ==============
+    allow httpd_t var_log_t:file read;
     allow httpd_t var_t:file { read getattr open };
 
      The run the following commands as root:

--- a/README
+++ b/README
@@ -49,7 +49,7 @@ Copyright (c) 2006-2013 Trend Micro Inc.
     allow httpd_t var_log_t:file read;
     allow httpd_t var_t:file { read getattr open };
 
-     The run the following commands as root:
+     Then run the following commands as root:
 
     checkmodule -M -m ossec-wui.te -o ossec-wui.mod
     semodule_package -o ossec-wui.pp -m ossec-wui.mod

--- a/README
+++ b/README
@@ -67,9 +67,6 @@ Copyright (c) 2006-2013 Trend Micro Inc.
 
 1.6- Try to access the UI.
 
-     http ://anyhost/ossec-wui/
+     http://anyhost/ossec-wui/
 
 1.7- Report any problems or suggestions to our mailing list.
-
-
-#EOF

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ Copyright (c) 2006-2013 Trend Micro Inc.
     # git clone https://github.com/ossec/ossec-wui.git
 
 
-1.2-Move the folder to somewhere acessible by
+1.2- Move the folder to somewhere acessible by
      your web server:
 
     # mv ossec-wui* /var/www/htdocs/ossec-wui
@@ -28,21 +28,30 @@ Copyright (c) 2006-2013 Trend Micro Inc.
     ...
 
 
-1.4- Add your web server user (apache, www-data or nobody) to the ossec group:
+1.4- If selinux is enabled, ossec-wui is normally unable to access 
+     various ossec log files.  One way to fix this is to install a 
+     selinux targeted policy.
 
-    # vi /etc/group
-    ..
-    From:
-        ossec:x:1002:
-    To (if your web server user is www-data):
-        ossec:x:1002:www-data
+     Create a TE file (eg. 
+     /etc/seliinux/targeted/ossec-wui/ossec-wui.te) with the following 
+     content:
 
-1.5- Fix the permissions for the tmp directory of your OSSEC installation (e.g., /var/ossec/tmp) and restart Apache
+    module ossec-wui 1.0;
 
-    # chmod 770 tmp/
-    # chgrp www-data tmp/
-    # apachectl restart
+    require {
+        type httpd_t;
+        type var_t;
+        class file { read getattr open };
+    }
 
+    #============= httpd_t ==============
+    allow httpd_t var_t:file { read getattr open };
+
+     The run the following commands as root:
+
+    checkmodule -M -m ossec-wui.te -o ossec-wui.mod
+    semodule_package -o ossec-wui.pp -m ossec-wui.mod
+    semodule -i ossec-wui.pp 
 
 1.5- If you have a large ossec install, you may want to
      re-configure PHP to support longer lasting scripts

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,8 @@ cd $LOCAL
 PWD=`pwd`
 ERRORS=0;
 
+trap "rm -f $TMPFILE; exit" SIGHUP SIGINT SIGTERM
+
 # Looking for echo -n
 ECHO="echo -n"
 hs=`echo -n "a"`
@@ -92,7 +94,10 @@ if grep ^ossec: /etc/group > /dev/null 2>&1; then
     if ! (echo $OSSEC | grep -w $HTTPDUSER) > /dev/null 2>&1; then
         NEWLINE="$OSSEC,$HTTPDUSER"
         NEWLINE=`echo $NEWLINE | sed -e 's/:,/:/'`
-        sed "s/$OSSEC/$NEWLINE/" -i /etc/group
+        TMPFILE=`mktemp`
+        sed "s/$OSSEC/$NEWLINE/" /etc/group > $TMPFILE
+        cp $TMPFILE /etc/group
+        rm -f $TMPFILE
         echo "You must restart your web server after this setup is done."
     fi
 else

--- a/setup.sh
+++ b/setup.sh
@@ -85,16 +85,20 @@ else
 fi
 
 # Adjust permissions for ossec-wui
-echo "Enter your web server user name (e.g. apache, www, nobody, www-data, ...)"
-read HTTPDUSER
 OSSEC=`grep ^ossec: /etc/group`
-if ! (echo $OSSEC | grep -w $HTTPDUSER) > /dev/null 2>&1; then
-    NEWLINE="$OSSEC,$HTTPDUSER"
-    NEWLINE=`echo $NEWLINE | sed -e 's/:,/:/'`
-    sed "s/$OSSEC/$NEWLINE/" -i /etc/group
+if grep ^ossec: /etc/group > /dev/null 2>&1; then
+    echo "Enter your web server user name (e.g. apache, www, nobody, www-data, ...)"
+    read HTTPDUSER
+    if ! (echo $OSSEC | grep -w $HTTPDUSER) > /dev/null 2>&1; then
+        NEWLINE="$OSSEC,$HTTPDUSER"
+        NEWLINE=`echo $NEWLINE | sed -e 's/:,/:/'`
+        sed "s/$OSSEC/$NEWLINE/" -i /etc/group
+        echo "You must restart your web server after this setup is done."
+    fi
+else
+    echo "ossec group does not exist."
+    ERRORS=1
 fi
-
-echo "You must restart your web server after this setup is done."
 
 if [ $ERRORS = 0 ]; then
     echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -86,14 +86,14 @@ fi
 
 # Adjust permissions for ossec-wui
 echo "Enter your web server user name (e.g. apache, www, nobody, www-data, ...)"
-read GROUP
-OSSEC=`grep ossec /etc/group`
-NEWLINE=$OSSEC$GROUP
-sed "s/$OSSEC/$NEWLINE/" -i /etc/group
-echo "Enter your OSSEC install directory path (e.g. /var/ossec)"
-read INSTALL
-chmod 770 $INSTALL/tmp/
-chgrp $GROUP $INSTALL/tmp/
+read HTTPDUSER
+OSSEC=`grep ^ossec: /etc/group`
+if ! (echo $OSSEC | grep -w $HTTPDUSER) > /dev/null 2>&1; then
+    NEWLINE="$OSSEC,$HTTPDUSER"
+    NEWLINE=`echo $NEWLINE | sed -e 's/:,/:/'`
+    sed "s/$OSSEC/$NEWLINE/" -i /etc/group
+fi
+
 echo "You must restart your web server after this setup is done."
 
 if [ $ERRORS = 0 ]; then


### PR DESCRIPTION
This makes setup.sh a little more robust in adding the HTTPD user to the ossec group.
It also removes the unnecessary permission change to /var/ossec/tmp which incidentally clobbers the /tmp directory permissions if the installer wasn't paying close attention to what the setup script is asking.
Lastly it updates the README file and adds selinux setup info. (issue #8).

