### PR TITLE
Replace 'split' to 'explode'

### DIFF
--- a/lib/os_lib_agent.php
+++ b/lib/os_lib_agent.php
@@ -108,7 +108,7 @@ function os_getagents($ossec_handle)
             /* Splitting the file. We may have multiple "-". */
             while(1)
             {
-                @list($_name, $_ip) = split("-", $tmp_file, 2);
+                @list($_name, $_ip) = explode("-", $tmp_file, 2);
                 
                 /* Nothing more to split */
                 if(!isset($_name) || !isset($_ip))


### PR DESCRIPTION
Split is deprecated PHP>5.3. Replace 'split' to 'explode' for working on PHP 7